### PR TITLE
Don't check body length

### DIFF
--- a/lib/em-xmlrpc-client.rb
+++ b/lib/em-xmlrpc-client.rb
@@ -97,8 +97,6 @@ module XMLRPC
       expected = resp["Content-Length"] || "<unknown>"
       if data.nil? or data.size == 0
         raise "Wrong size. Was #{data.size}, should be #{expected}"
-      elsif expected != "<unknown>" and expected.to_i != data.size and resp["Transfer-Encoding"].nil?
-        raise "Wrong size. Was #{data.size}, should be #{expected}"
       end
 
       set_cookies = resp.get_fields("Set-Cookie")


### PR DESCRIPTION
This backports the following commit:
https://github.com/ruby/ruby/commit/fc3b4d06ca4f5c46457983b51f844f5afcd325df

```
* lib/xmlrpc/client.rb (do_rpc): don't check body length.

  If HTTP content-encoding is used, the length may be different.
  [Bug #8182] [ruby-core:53811]

git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/trunk@45529 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
```
It is also worth mentioning, that xmlrpc is extracted into separate gem
during ruby 2.4.0 preparation:
https://github.com/ruby/ruby/commit/e2bb529c8f77a1a2911b13f1949c8813ee29f740

```
* lib/xmlrpc.rb, lib/xmlrpc/*, test/xmlrpc: XMLRPC is bundled gem

  on Ruby 2.4. [Feature #12160][ruby-core:74239]
* gems/bundled_gems: ditto.

git-svn-id: svn+ssh://ci.ruby-lang.org/ruby/trunk@55013 b2dd03c8-39d4-4d8f-98ff-823fe69b080e
```